### PR TITLE
chore: add notice about zod v4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A set of utilities to work with Zod errors.
 
+> [!IMPORTANT]
+> This package is not recommended to use for Zod V4, as it has better support for error messages and paths.
+> See the [Zod V4 documentation](https://zod.dev/error-formatting#zprettifyerror) for more information.
+
 ## 📦 Installation
 
 ```bash


### PR DESCRIPTION
This PR resolves #63.

Since Zod V4 has great support for prettifing the error messages, there is not reason to support Zod V4.